### PR TITLE
fix: 修正 PR #12 rebase 到 dev 後執行會出現 error 跟 bug 的問題

### DIFF
--- a/fitcal/urls.py
+++ b/fitcal/urls.py
@@ -6,5 +6,5 @@ urlpatterns = [
     path('', include('pages.urls', namespace='pages')),
     path('users/', include('users.urls', namespace='users')),
     path('members/', include('members.urls', namespace='members')),
-    path('orders/', include('orders.urls'), namespace='orders'),
+    path('orders/', include('orders.urls', namespace='orders')),
 ]

--- a/orders/templatetags/datetime_format.py
+++ b/orders/templatetags/datetime_format.py
@@ -5,10 +5,10 @@ register = template.Library()
 
 
 @register.filter
-def datetime_format(value, format='%Y年%-m月%-d日 %H:%M'):
+def datetime_format(value, format='%Y年%m月%d日 %H:%M'):
     """
     將 datetime 格式化為自訂格式。
-    預設格式為：2025年5月7日 16:40
+    預設格式為：2025年05月07日 16:40
     """
     if not value:
         return ''


### PR DESCRIPTION
#31 

## fix error

fitcal/urls.py 
```python
urlpatterns = [
    path('admin/', admin.site.urls),
    path('', include('pages.urls', namespace='pages')),
    path('users/', include('users.urls', namespace='users')),
    path('members/', include('members.urls', namespace='members')),
    path('orders/', include('orders.urls'), namespace='orders'),
]
```

原本會有： `TypeError: _path() got an unexpected keyword argument 'namespace'`

`path('orders/' include('orders.urls'), namespace='orders'),` 

修正成：

`path('orders/', include('orders.urls', namespace='orders')),`

---

## bug: `datetime format` 在 Windows 與 macOS 不相容

在使用 `strftime('%Y年%-m月%-d日 %H:%M')` 進行日期格式化時，macOS 上執行正常，但在 Windows 上會出現格式錯誤。


`datetime format` windows 跟 mac 有不相容的地方:

> datetime 格式字串 `strftime('%Y年%-m月%-d日 %H:%M')` 在 mac 上可行，但 Windows 出現格式錯誤，這是因為它依賴的平台上的 strftime 行為不同

## 📌 問題說明

* 格式中的 `%-m` 與 `%-d` 為 GNU 擴充語法，用來去除前導 0。
* 此語法支援於 macOS 與 Linux（GNU date / Python），但 **不支援 Windows 的 Python 環境**。
* 在 Windows 上會拋出錯誤：`ValueError: '-' is a bad directive in format '%-m'`。

## ✅ 解法

將格式字串修改為：

```python
'%Y年%m月%d日 %H:%M'
```

雖然保留了前導 0，但可跨平台正常運作

