### PR TITLE
建立客製化 404 頁面

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ node_modules
 /static/assets/styles/style.css
 /static/assets/scripts/app.js
 
+# collectstatic
 staticfiles
 
 # Others

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 runserver:
 	uv run manage.py runserver
 
+runserver-prod:
+	uv run python manage.py collectstatic --noinput && DEBUG=False uv run manage.py runserver
+
 makemigrations:
 	uv run manage.py makemigrations
 

--- a/fitcal/settings.py
+++ b/fitcal/settings.py
@@ -83,6 +83,7 @@ ACCOUNT_SIGNUP_FIELDS = ['email*', 'password1*', 'password2*']
 MIDDLEWARE = [
     'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -194,9 +195,12 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = 'static/'
+# 開發階段放前端打包檔的資料夾
 STATICFILES_DIRS = [
     BASE_DIR / 'static',
 ]
+# collectstatic 收集到此資料夾
+STATIC_ROOT = BASE_DIR / 'staticfiles'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "reset": "npm install && npm prune",
     "dev": "concurrently --kill-others --names \"esbuild,tailwind,django\" -c \"yellow,blue,green\" \"esbuild ./src/scripts/input.js --bundle --outfile=./static/assets/scripts/app.js --watch\" \"npx @tailwindcss/cli -i ./src/styles/input.css -o ./static/assets/styles/style.css --watch\" \"uv run manage.py runserver\"",
+    "prod": "concurrently --kill-others --names \"esbuild,tailwind,django\" -c \"yellow,blue,green\" \"esbuild ./src/scripts/input.js --bundle --outfile=./static/assets/scripts/app.js --watch\" \"npx @tailwindcss/cli -i ./src/styles/input.css -o ./static/assets/styles/style.css --watch\" \"uv run python manage.py collectstatic --noinput && DEBUG=False uv run manage.py runserver\"",
     "watch": "concurrently --kill-others --names \"esbuild,tailwind\" -c \"yellow,blue\" \"esbuild ./src/scripts/input.js --bundle --outfile=./static/assets/scripts/app.js --watch\" \"npx @tailwindcss/cli -i ./src/styles/input.css -o ./static/assets/styles/style.css --watch\"",
     "build": "esbuild ./src/scripts/input.js --bundle --outfile=./static/assets/scripts/app.js && npx @tailwindcss/cli -i ./src/styles/input.css -o ./static/assets/styles/style.css --minify"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pillow>=11.2.1",
     "psycopg[binary]>=3.2.7",
     "django-widget-tweaks>=1.5.0",
+    "whitenoise>=6.9.0",
 ]
 
 [dependency-groups]

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,29 @@
+{% load static %}
+<!doctype html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>找不到頁面 - FitCal 健康餐訂餐平台</title>
+    <link rel="stylesheet" href="{% static 'assets/styles/style.css' %}" />
+  </head>
+  <body class="bg-green-50 flex items-center justify-center h-screen">
+    <div class="text-center p-8 bg-white shadow-xl rounded-2xl max-w-md">
+      <img
+        src="https://img.icons8.com/fluency/96/vegetarian-food.png"
+        alt="Healthy Food Icon"
+        class="mx-auto mb-4"
+      />
+
+      <h1 class="text-4xl font-bold text-green-700 mb-2">404 - 找不到頁面</h1>
+      <p class="text-gray-600 mb-6">很抱歉，這個頁面好像被吃掉了！試著返回看看別的美味選項吧。</p>
+
+      <button
+        onclick="history.back()"
+        class="bg-green-600 hover:bg-green-700 text-white font-semibold px-6 py-2 rounded-full transition"
+      >
+        返回上一頁
+      </button>
+    </div>
+  </body>
+</html>

--- a/templates/404.html
+++ b/templates/404.html
@@ -8,22 +8,16 @@
     <link rel="stylesheet" href="{% static 'assets/styles/style.css' %}" />
   </head>
   <body class="bg-green-50 flex items-center justify-center h-screen">
-    <div class="text-center p-8 bg-white shadow-xl rounded-2xl max-w-md">
-      <img
-        src="https://img.icons8.com/fluency/96/vegetarian-food.png"
-        alt="Healthy Food Icon"
-        class="mx-auto mb-4"
-      />
+    <div class="text-center p-8 sm:p-12 bg-white shadow-xl rounded-2xl max-w-md w-11/12">
+      <h1 class="text-4xl sm:text-4xl font-bold text-green-700 mb-8 mt-8">404 - 找不到頁面</h1>
 
-      <h1 class="text-4xl font-bold text-green-700 mb-2">404 - 找不到頁面</h1>
-      <p class="text-gray-600 mb-6">很抱歉，這個頁面好像被吃掉了！試著返回看看別的美味選項吧。</p>
+      <img src="{% static 'images/logo.png' %}" alt="Fitcal Logo" class="mx-auto mb-4 w-50 sm:w-45" />
+      <!-- Adjusted logo size with w-36 or w-40 and margin -->
 
-      <button
-        onclick="history.back()"
-        class="bg-green-600 hover:bg-green-700 text-white font-semibold px-6 py-2 rounded-full transition"
-      >
-        返回上一頁
-      </button>
+      <p class="text-green-700 mb-10 text-xl sm:text-2xl">Fit Your Calories, Fit Your Life.</p>
+      <!-- Adjusted slogan size and margin -->
+
+      <button onclick="history.back()" class="bg-green-600 hover:bg-green-700 text-white font-semibold px-8 py-3 rounded-full transition text-lg mt-5">返回上一頁</button>
     </div>
   </body>
 </html>

--- a/uv.lock
+++ b/uv.lock
@@ -266,6 +266,7 @@ dependencies = [
     { name = "email-validator" },
     { name = "pillow" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "whitenoise" },
 ]
 
 [package.dev-dependencies]
@@ -286,6 +287,7 @@ requires-dist = [
     { name = "email-validator", specifier = ">=2.2.0" },
     { name = "pillow", specifier = ">=11.2.1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.7" },
+    { name = "whitenoise", specifier = ">=6.9.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -539,4 +541,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672, upload-time = "2025-04-10T15:23:39.232Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680, upload-time = "2025-04-10T15:23:37.377Z" },
+]
+
+[[package]]
+name = "whitenoise"
+version = "6.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/cf/c15c2f21aee6b22a9f6fc9be3f7e477e2442ec22848273db7f4eb73d6162/whitenoise-6.9.0.tar.gz", hash = "sha256:8c4a7c9d384694990c26f3047e118c691557481d624f069b7f7752a2f735d609", size = 25920 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b2/2ce9263149fbde9701d352bda24ea1362c154e196d2fda2201f18fc585d7/whitenoise-6.9.0-py3-none-any.whl", hash = "sha256:c8a489049b7ee9889617bb4c274a153f3d979e8f51d2efd0f5b403caf41c57df", size = 20161 },
 ]


### PR DESCRIPTION
close #60 

此 PR 新增一個客製化的 404 頁面，用於當使用者造訪不存在的路由時，顯示美觀且風格一致的錯誤訊息。頁面使用 **健康餐平台**風格設計，搭配 TailwindCSS 進行排版

## 🔧 主要變更內容

* `templates/404.html`:

  新增客製化 404 頁面 Template

> 為什麼不能把 `404.html` 放在 `templates/pages/`？

Django 對 404 頁面的處理行為如下：

* `handler404` 預設會尋找 `templates/404.html`（**根層級**），不是子目錄。
* 放在 `templates/pages/404.html` 會導致在 production 模式（`DEBUG=False`）時無法正確顯示客製化的錯誤頁面，因為 Django 會回傳 production 模式預設的錯誤頁。
* 因此，**`404.html` 必須直接位於 `templates/` 根目錄下** 才能被自動載入。

---

* `settings.py` 調整：

  * 新增 `STATIC_ROOT`
  * 安裝whitenoise 套件，啟用 `whitenoise.middleware.WhiteNoiseMiddleware`。

## 🧪 使用方式

* 執行 `npm run prod` 或 `uv run python manage.py collectstatic --noinput && DEBUG=False uv run manage.py runserver`
  或者 `make runserver-prod`

（windows 應該要用 `$env:DJANGO_DEBUG="False"; uv run python manage.py runserver`)

* 訪問不存在的路由，例如：`http://127.0.0.1:8000/not-found`

應可看到如下畫面：

![image](https://github.com/user-attachments/assets/0b68876a-9fc1-4ef0-9bed-c62887f13994)


---
## 為什麼需要 Whitenoise？

* 在 `DEBUG=False` 模式下，Django 不再自動服務 `STATICFILES_DIRS` 中的資源。
* 若不使用 Web server（如 nginx）或 CDN，就需要使用 Whitenoise 這類中介層來處理靜態檔案。
* Whitenoise 會處理 `collectstatic` 後存於 `STATIC_ROOT` 中的檔案，並用正確的 MIME type 回應。
* 若缺少 Whitenoise，瀏覽器將拒絕載入 `.css`、`.js` 等靜態檔，導致 404 頁面樣式與互動全部失效。

---

## 備註

* 若未使用 CDN 或 Nginx，請保留 Whitenoise middleware。
* 若將來以 Docker/Nginx/CDN 作為靜態檔主責，可移除 Whitenoise 提升效能，但目前仍建議保留。
* 若使用 GitHub Actions 自動部署，也請加上 collectstatic 步驟。



