### PR TITLE
子選單及會員資料切版

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@tailwindcss/cli": "^4.1.4",
     "autoprefixer": "^10.4.21",
     "concurrently": "^9.1.2",
-    "daisyui": "^5.0.35",
+    "daisyui": "^5.0.37",
     "esbuild": "^0.25.4",
     "eslint": "^9.26.0",
     "eslint-config-prettier": "^10.1.2",

--- a/templates/layouts/default.html
+++ b/templates/layouts/default.html
@@ -12,7 +12,7 @@
   <body class="min-h-screen flex flex-col" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
    <main class="flex-1">
     <section class="max-w-5xl mx-auto">
-    {% include 'shared/navbar.html' %}
+    <nav>{% include 'shared/navbar.html' %}</nav>
     {% include 'shared/messages.html' %}
       {% if user.is_authenticated %}
       <div class="flex justify-end">

--- a/templates/members/index.html
+++ b/templates/members/index.html
@@ -1,10 +1,25 @@
 {% extends 'layouts/default.html' %} {% block main %}
 <h1>會員列表</h1>
-{% if member %}
-<a href="{% url 'members:show' member.id %}">
-  <p>{{ member.id }}</p>
-  <p>{{ member.phone }}</p>
-</a>
-{% else %}
-<a href="{% url 'members:new' %}" class="btn">新增會員資料</a>
-{% endif %} {% endblock main %}
+
+<div class="max-w-xl mx-auto bg-white text-black p-6 mt-10 rounded-2xl shadow-lg">
+  <h2 class="text-2xl font-semibold mb-4 border-b pb-2 border-gray-200">會員資料</h2>
+  <img src="https://i.pinimg.com/736x/43/14/0a/43140a3803e5f1b39c1ffac1a35a3ec7.jpg" alt="頭像" class="w-32 h-32 object-cover rounded-full mb-4 border border-black" />
+
+  <p class="mb-2"><span class="font-bold">ID：</span>{{ member.id }}</p>
+  <p class="mb-2"><span class="font-bold">姓名：</span>{{ member.name }}</p>
+  <p class="mb-2"><span class="font-bold">電話：</span>{{ member.phone_number }}</p>
+  <p class="mb-2"><span class="font-bold">性別：</span>{{ member.get_gender_display }}</p>
+  <p class="mb-2"><span class="font-bold">生日：</span>{{ member.date_of_birth|date:'Y-m-d' }}</p>
+  <p class="mb-2"><span class="font-bold">LINE：</span>{{ member.line_id|default:'未連結' }}</p>
+  <p class="mb-2"><span class="font-bold">Google：</span>{{ member.google_id|default:'未連結' }}</p>
+  <p class="mb-2"><span class="font-bold">建立時間：</span>{{ member.created_at|date:'Y-m-d H:i' }}</p>
+  <p class="mb-2"><span class="font-bold">更新時間：</span>{{ member.updated_at|date:'Y-m-d H:i' }}</p>
+  <div class="flex flex-wrap gap-4 mt-4">
+    <a href="{% url 'members:edit' member.id %}" class="inline-block mt-4 px-4 py-2 bg-black text-white rounded hover:bg-gray-800">編輯資料</a>
+    <form action="{% url 'members:delete' member.id %}" method="post" onsubmit="return confirm(是否確認刪除帳號與會員？此操作無法復原！');">
+      {% csrf_token %}
+      <button type="submit" class="inline-block mt-4 px-4 py-2 bg-black text-white rounded hover:bg-gray-800">刪除帳號與會員</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/templates/members/index.html
+++ b/templates/members/index.html
@@ -1,6 +1,4 @@
 {% extends 'layouts/default.html' %} {% block main %}
-<h1>會員列表</h1>
-
 <div class="max-w-xl mx-auto bg-white text-black p-6 mt-10 rounded-2xl shadow-lg">
   <h2 class="text-2xl font-semibold mb-4 border-b pb-2 border-gray-200">會員資料</h2>
   <img src="https://i.pinimg.com/736x/43/14/0a/43140a3803e5f1b39c1ffac1a35a3ec7.jpg" alt="頭像" class="w-32 h-32 object-cover rounded-full mb-4 border border-black" />

--- a/templates/shared/navbar.html
+++ b/templates/shared/navbar.html
@@ -3,59 +3,58 @@
     <a href="/" class="btn btn-ghost text-3xl">FITCAL</a>
   </div>
   <div class="flex-none flex items-center gap-0">
-    {% comment %} search bar {% endcomment %}
+    <!-- search bar -->
     <input type="text" placeholder="Search" class="input input-bordered w-24 md:w-auto" />
 
-    {% comment %} 已登入購物車和個人資料狀態 {% endcomment %} 
-    {% if user.is_authenticated %} 
-    {% comment %} cart {% endcomment %}
-      <a href="{% url 'carts:index' %}" class="btn btn-ghost btn-circle avatar" tabindex="0">
-        <div class="indicator">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-8 w-8"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"
-            />
-          </svg>
-        </div>
-      </a>
+    <!-- 已登入購物車和個人資料狀態 -->
+    {% if user.is_authenticated %}
 
-      {% comment %} 個人資料 {% endcomment %}
-      <div class="dropdown dropdown-end">
-        <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar" tabindex="0">
-          <div class="w-10 rounded-full">
-            <img
-              alt="Tailwind CSS Navbar component"
-              src="https://i.pinimg.com/736x/43/14/0a/43140a3803e5f1b39c1ffac1a35a3ec7.jpg"
-            />
-          </div>
-        </div>
-        <ul
-          tabindex="0"
-          class="menu menu-sm dropdown-content bg-base-100 rounded-box z-1 mt-3 w-52 p-2 shadow"
-        >
-          <li>
-            <a class="justify-between">
-              Profile
-              <span class="badge">New</span>
-            </a>
-          </li>
-          <li><a>Settings</a></li>
-          <li><a>Logout</a></li>
-        </ul>
+    <!-- cart -->
+    <a href="{% url 'carts:index' %}" class="btn btn-ghost btn-circle avatar" tabindex="0">
+      <div class="indicator">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z" />
+        </svg>
       </div>
+    </a>
+
+    <!--- 個人資料 -->
+    <div class="dropdown dropdown-end">
+      <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar" tabindex="0">
+        <div class="w-10 rounded-full">
+          <img alt="Tailwind CSS Navbar component" src="https://i.pinimg.com/736x/43/14/0a/43140a3803e5f1b39c1ffac1a35a3ec7.jpg" />
+        </div>
+      </div>
+
+      <!--- 子選單 -->
+      <ul tabindex="0" class="menu dropdown-content bg-base-100 rounded-box z-1 mt-3 w-72 p-4 shadow gap-6">
+        <li>
+          <a href="{% url 'members:index' %}">帳號設定(編輯會員資料)</a>
+        </li>
+        <li>
+          <!--- 補上連結 -->
+          <a>收藏商家</a>
+        </li>
+        <li>
+          <!--- 補上連結 -->
+          <a>收藏商品</a>
+        </li>
+        <li>
+          <a>訂單管理</a>
+        </li>
+        <li>
+          <form action="{% url "users:delete_session" %}" method="post">
+          {% csrf_token %}
+          <button type="submit" class="btn">登出</button>
+          </form>
+        </li>
+      </ul>
+    </div>
     {% else %}
-      <a href="{% url 'users:sign_in' %}" class="btn bg-black text-white hover:bg-gray-800">登入</a>
-      <a href="{% url 'users:sign_up' %}" class="btn bg-black text-white hover:bg-gray-800">註冊</a>
+    <!-- 未登入狀態：登入/註冊按鈕 -->
+    <a href="{% url 'users:sign_in' %}" class="btn bg-black text-white hover:bg-gray-800">登入</a>
+    <a href="{% url 'users:sign_up' %}" class="btn bg-black text-white hover:bg-gray-800">註冊</a>
     {% endif %}
-    
   </div>
 </div>
+

--- a/templates/shared/navbar_login.html
+++ b/templates/shared/navbar_login.html
@@ -1,0 +1,29 @@
+<div class="navbar bg-base-100 shadow-sm">
+  <div class="flex-1">
+    <a class="btn btn-ghost text-xl">daisyUI</a>
+  </div>
+  <div class="flex gap-2">
+    <input type="text" placeholder="Search" class="input input-bordered w-24 md:w-auto" />
+    <div class="dropdown dropdown-end">
+      <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar">
+        <div class="w-10 rounded-full">
+          <img
+            alt="Tailwind CSS Navbar component"
+            src="https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp" />
+        </div>
+      </div>
+      <ul
+        tabindex="0"
+        class="menu menu-sm dropdown-content bg-base-100 rounded-box z-1 mt-3 w-52 p-2 shadow">
+        <li>
+          <a class="justify-between">
+            Profile
+            <span class="badge">New</span>
+          </a>
+        </li>
+        <li><a>Settings</a></li>
+        <li><a>Logout</a></li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/templates/shared/navbar_login.html
+++ b/templates/shared/navbar_login.html
@@ -7,7 +7,7 @@
     <input type="text" placeholder="Search" class="input input-bordered w-24 md:w-auto" />
 
     <!--- 已登入購物車和個人資料狀態 -->
-    {% if user.is_authenticated %}
+    {% if user.is_authenticated %} 
     <!--- cart -->
     <a href="{% url 'carts:index' %}" class="btn btn-ghost btn-circle avatar" tabindex="0">
       <div class="indicator">
@@ -45,21 +45,26 @@
         class="menu dropdown-content bg-base-100 rounded-box z-1 mt-3 w-72 p-4 shadow gap-6"
       >
         <li>
-          <a>帳號設定(編輯會員資料)</a>
+          <a href="{% url 'members:index' %}">帳號設定(編輯會員資料)</a>
         </li>
         <li>
+          <!--- 補上連結 -->
           <a>收藏商家</a>
         </li>
         <li>
+          <!--- 補上連結 -->
           <a>收藏商品</a>
         </li>
         <li>
           <a>訂單管理</a>
         </li>
         <li>
-          <a href="{% url 'users:select_role' %}" class="btn bg-black text-white hover:bg-gray-800"
-            >登出</a
-          >
+          </form>
+          {% if request.user.is_authenticated %}
+          <form method="POST" action="{% url 'users:delete_session' %}" class="inline-block mt-4 px-4 py-2 bg-black text-white rounded hover:bg-gray-800">
+            {% csrf_token %}
+            <button type="submit">登出</button>
+          </form>
         </li>
       </ul>
     </div>
@@ -69,3 +74,4 @@
     {% endif %}
   </div>
 </div>
+{% endif %}

--- a/templates/shared/navbar_login.html
+++ b/templates/shared/navbar_login.html
@@ -3,59 +3,69 @@
     <a href="/" class="btn btn-ghost text-3xl">FITCAL</a>
   </div>
   <div class="flex-none flex items-center gap-0">
-    {% comment %} search bar {% endcomment %}
+    <!--- search bar -->
     <input type="text" placeholder="Search" class="input input-bordered w-24 md:w-auto" />
 
-    {% comment %} 已登入購物車和個人資料狀態 {% endcomment %} 
-    {% if user.is_authenticated %} 
-    {% comment %} cart {% endcomment %}
-      <a href="{% url 'carts:index' %}" class="btn btn-ghost btn-circle avatar" tabindex="0">
-        <div class="indicator">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-8 w-8"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"
-            />
-          </svg>
-        </div>
-      </a>
-
-      {% comment %} 個人資料 {% endcomment %}
-      <div class="dropdown dropdown-end">
-        <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar" tabindex="0">
-          <div class="w-10 rounded-full">
-            <img
-              alt="Tailwind CSS Navbar component"
-              src="https://i.pinimg.com/736x/43/14/0a/43140a3803e5f1b39c1ffac1a35a3ec7.jpg"
-            />
-          </div>
-        </div>
-        <ul
-          tabindex="0"
-          class="menu menu-sm dropdown-content bg-base-100 rounded-box z-1 mt-3 w-52 p-2 shadow"
+    <!--- 已登入購物車和個人資料狀態 -->
+    {% if user.is_authenticated %}
+    <!--- cart -->
+    <a href="{% url 'carts:index' %}" class="btn btn-ghost btn-circle avatar" tabindex="0">
+      <div class="indicator">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-8 w-8"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
         >
-          <li>
-            <a class="justify-between">
-              Profile
-              <span class="badge">New</span>
-            </a>
-          </li>
-          <li><a>Settings</a></li>
-          <li><a>Logout</a></li>
-        </ul>
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"
+          />
+        </svg>
       </div>
+    </a>
+
+    <!--- 個人資料 -->
+    <div class="dropdown dropdown-end">
+      <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar" tabindex="0">
+        <div class="w-10 rounded-full">
+          <img
+            alt="Tailwind CSS Navbar component"
+            src="https://i.pinimg.com/736x/43/14/0a/43140a3803e5f1b39c1ffac1a35a3ec7.jpg"
+          />
+        </div>
+      </div>
+
+      <!--- 子選單 -->
+      <ul
+        tabindex="0"
+        class="menu dropdown-content bg-base-100 rounded-box z-1 mt-3 w-72 p-4 shadow gap-6"
+      >
+        <li>
+          <a>帳號設定(編輯會員資料)</a>
+        </li>
+        <li>
+          <a>收藏商家</a>
+        </li>
+        <li>
+          <a>收藏商品</a>
+        </li>
+        <li>
+          <a>訂單管理</a>
+        </li>
+        <li>
+          <a href="{% url 'users:select_role' %}" class="btn bg-black text-white hover:bg-gray-800"
+            >登出</a
+          >
+        </li>
+      </ul>
+    </div>
     {% else %}
-      <a href="{% url 'users:sign_in' %}" class="btn bg-black text-white hover:bg-gray-800">登入</a>
-      <a href="{% url 'users:sign_up' %}" class="btn bg-black text-white hover:bg-gray-800">註冊</a>
+    <a href="{% url 'users:sign_in' %}" class="btn bg-black text-white hover:bg-gray-800">登入</a>
+    <a href="{% url 'users:sign_up' %}" class="btn bg-black text-white hover:bg-gray-800">註冊</a>
     {% endif %}
-    
   </div>
 </div>

--- a/templates/shared/navbar_login.html
+++ b/templates/shared/navbar_login.html
@@ -1,20 +1,45 @@
 <div class="navbar bg-base-100 shadow-sm">
   <div class="flex-1">
-    <a class="btn btn-ghost text-xl">daisyUI</a>
+    <a href="/" class="btn btn-ghost text-3xl">FITCAL</a>
   </div>
-  <div class="flex gap-2">
+  <div class="flex-none flex items-center gap-1">
+    {% comment %} search bar {% endcomment %}
     <input type="text" placeholder="Search" class="input input-bordered w-24 md:w-auto" />
+
+    {% comment %} cart {% endcomment %}
+    <a href="http://127.0.0.1:8000/carts/" class="btn btn-ghost btn-circle" tabindex="0">
+      <div class="indicator">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-5 w-5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"
+          />
+        </svg>
+      </div>
+    </a>
+
+    {% comment %} 個人資料 {% endcomment %}
     <div class="dropdown dropdown-end">
       <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar">
         <div class="w-10 rounded-full">
           <img
             alt="Tailwind CSS Navbar component"
-            src="https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp" />
+            src="https://i.pinimg.com/736x/43/14/0a/43140a3803e5f1b39c1ffac1a35a3ec7.jpg"
+          />
         </div>
       </div>
       <ul
         tabindex="0"
-        class="menu menu-sm dropdown-content bg-base-100 rounded-box z-1 mt-3 w-52 p-2 shadow">
+        class="menu menu-sm dropdown-content bg-base-100 rounded-box z-1 mt-3 w-52 p-2 shadow"
+      >
         <li>
           <a class="justify-between">
             Profile

--- a/templates/shared/navbar_login.html
+++ b/templates/shared/navbar_login.html
@@ -2,53 +2,60 @@
   <div class="flex-1">
     <a href="/" class="btn btn-ghost text-3xl">FITCAL</a>
   </div>
-  <div class="flex-none flex items-center gap-1">
+  <div class="flex-none flex items-center gap-0">
     {% comment %} search bar {% endcomment %}
     <input type="text" placeholder="Search" class="input input-bordered w-24 md:w-auto" />
 
+    {% comment %} 已登入購物車和個人資料狀態 {% endcomment %} 
+    {% if user.is_authenticated %} 
     {% comment %} cart {% endcomment %}
-    <a href="http://127.0.0.1:8000/carts/" class="btn btn-ghost btn-circle" tabindex="0">
-      <div class="indicator">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="h-5 w-5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"
-          />
-        </svg>
-      </div>
-    </a>
-
-    {% comment %} 個人資料 {% endcomment %}
-    <div class="dropdown dropdown-end">
-      <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar">
-        <div class="w-10 rounded-full">
-          <img
-            alt="Tailwind CSS Navbar component"
-            src="https://i.pinimg.com/736x/43/14/0a/43140a3803e5f1b39c1ffac1a35a3ec7.jpg"
-          />
+      <a href="{% url 'carts:index' %}" class="btn btn-ghost btn-circle avatar" tabindex="0">
+        <div class="indicator">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-8 w-8"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"
+            />
+          </svg>
         </div>
+      </a>
+
+      {% comment %} 個人資料 {% endcomment %}
+      <div class="dropdown dropdown-end">
+        <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar" tabindex="0">
+          <div class="w-10 rounded-full">
+            <img
+              alt="Tailwind CSS Navbar component"
+              src="https://i.pinimg.com/736x/43/14/0a/43140a3803e5f1b39c1ffac1a35a3ec7.jpg"
+            />
+          </div>
+        </div>
+        <ul
+          tabindex="0"
+          class="menu menu-sm dropdown-content bg-base-100 rounded-box z-1 mt-3 w-52 p-2 shadow"
+        >
+          <li>
+            <a class="justify-between">
+              Profile
+              <span class="badge">New</span>
+            </a>
+          </li>
+          <li><a>Settings</a></li>
+          <li><a>Logout</a></li>
+        </ul>
       </div>
-      <ul
-        tabindex="0"
-        class="menu menu-sm dropdown-content bg-base-100 rounded-box z-1 mt-3 w-52 p-2 shadow"
-      >
-        <li>
-          <a class="justify-between">
-            Profile
-            <span class="badge">New</span>
-          </a>
-        </li>
-        <li><a>Settings</a></li>
-        <li><a>Logout</a></li>
-      </ul>
-    </div>
+    {% else %}
+      <a href="{% url 'users:sign_in' %}" class="btn bg-black text-white hover:bg-gray-800">登入</a>
+      <a href="{% url 'users:sign_up' %}" class="btn bg-black text-white hover:bg-gray-800">註冊</a>
+    {% endif %}
+    
   </div>
 </div>


### PR DESCRIPTION
close #80

**切版說明**
1. 點選**子選單**可進入會員資料介面，目前收藏商家、收藏商品及訂單管理尚未增加連結，待網址確認後填入。
2. **會員資料**目前切到查看的介面，點選編輯按鈕後的編輯介面尚未切版，已開#112待製作。

<img width="1440" alt="截圖 2025-05-25 上午11 26 23" src="https://github.com/user-attachments/assets/61af2f19-4363-48fb-98ff-29c8b74e69f1" />



