### PR TITLE
修復： 登入註冊等異常

### DIFF
--- a/fitcal/settings.py
+++ b/fitcal/settings.py
@@ -204,6 +204,9 @@ STATICFILES_DIRS = [
 
 AUTH_USER_MODEL = 'users.User'
 
+# 未登入狀態下的轉址
+LOGIN_URL = 'users:sign_in'
+
 # 所有登入後的轉址地址
 LOGIN_REDIRECT_URL = '/'
 

--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -8,19 +8,4 @@
   button {
     @apply cursor-pointer;
   }
-
-  h2 {
-    @apply text-xl md:text-2xl lg:text-3xl font-bold;
-  }
-
-  h3 {
-    @apply text-lg font-semibold mb-2;
-  }
-  p {
-    @apply text-sm text-gray-600;
-  }
-
-  .card{
-    @apply grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-1 max-w-full justify-items-center
-  }
 }

--- a/templates/members/edit.html
+++ b/templates/members/edit.html
@@ -1,6 +1,6 @@
 {% extends 'layouts/default.html' %} {% block main %}
 <h1>編輯會員資料</h1>
-<form method="POST" action="{% url 'members:edit' member.id %}">
+<form method="POST" action="{% url 'members:show' member.id %}">
   {% csrf_token %} {% for field in form %}
   <div>
     {{ field.label_tag }} {{ field }} {% if field.help_text %}

--- a/templates/members/new.html
+++ b/templates/members/new.html
@@ -2,12 +2,13 @@
 <form method="POST" action="{% url 'members:create_member' %}">
   {% csrf_token %} {% for field in form %}
   <div>{{ field.label_tag }} {{ field }}</div>
-  {% endfor %}
+  {% for error in field.errors %}
+  <div class="text-red-500">{{ error }}</div>
+  {% endfor %} {% endfor %}
   <div>
     <button class="btn" type="submit">新增會員</button>
     <a href="{% url 'members:index' %}" class="btn">取消</a>
   </div>
-  {{ form.errors }}
 </form>
 
 {% endblock main %}

--- a/users/views.py
+++ b/users/views.py
@@ -66,15 +66,14 @@ def create_session(req):
 
     if user.is_member:
         messages.success(req, '會員登入成功！')
-        return redirect('members:index')
     elif user.is_store:
         messages.success(req, '店家登入成功！')
-        return redirect('stores:index')
     else:
         logout(req)
         user.delete()
         messages.error(req, '帳號存在異常，請重新註冊')
         return redirect('users:sign_up')
+    return redirect('stores:index')
 
 
 # 處理登出 (POST)


### PR DESCRIPTION
close #118 


第三方登入後的轉址異常

無法註冊帳號

會員資料無法正確編輯

調整登出後轉址路徑

Tailwind移除沒有用到的自定樣式

修復因為身份驗證裝飾器功能調整後，造成的頁面無法正常載入，被阻擋