### PR TITLE
用 HTMX 改善訂單狀態切換體驗

### DIFF
--- a/orders/views.py
+++ b/orders/views.py
@@ -171,41 +171,65 @@ def cancel(request, id):
     if hasattr(request.user, 'store') and request.user.store:
         by_store = True
 
-    if service.cancel_order(by_store=by_store):
+    success = service.cancel_order(by_store=by_store)
+    order = get_object_or_404(Order, id=id)
+
+    if success:
         messages.success(request, '訂單已取消')
     else:
         messages.error(request, '此訂單無法取消')
-    return redirect('orders:show', id=id)
+
+    return render(
+        request, 'shared/order/partial_order_status_response.html', {'order': order}
+    )
 
 
 def prepare(request, id):
     """開始準備訂單"""
-    order = get_object_or_404(Order, id=id)
     service = OrderService(id)
-    if service.prepare_order():
+
+    success = service.prepare_order()
+    order = get_object_or_404(Order, id=id)
+
+    if success:
         messages.success(request, '訂單開始準備中')
     else:
         messages.error(request, '此訂單無法開始準備')
-    return redirect('stores:manage_orders', store_id=order.store.id)
+
+    return render(
+        request, 'shared/order/partial_order_status_response.html', {'order': order}
+    )
 
 
 def mark_ready(request, id):
     """標記訂單準備完成"""
-    order = get_object_or_404(Order, id=id)
     service = OrderService(id)
-    if service.mark_order_ready():
+
+    success = service.mark_order_ready()
+    order = get_object_or_404(Order, id=id)
+
+    if success:
         messages.success(request, '訂單已準備完成')
     else:
         messages.error(request, '此訂單無法標記為準備完成')
-    return redirect('stores:manage_orders', store_id=order.store.id)
+
+    return render(
+        request, 'shared/order/partial_order_status_response.html', {'order': order}
+    )
 
 
 def complete(request, id):
     """完成訂單（顧客取餐）"""
-    order = get_object_or_404(Order, id=id)
     service = OrderService(id)
-    if service.complete_order():
+
+    success = service.complete_order()
+    order = get_object_or_404(Order, id=id)
+
+    if success:
         messages.success(request, '訂單已完成')
     else:
         messages.error(request, '此訂單無法標記為完成')
-    return redirect('stores:manage_orders', store_id=order.store.id)
+
+    return render(
+        request, 'shared/order/partial_order_status_response.html', {'order': order}
+    )

--- a/templates/orders/components/ordering_step3.html
+++ b/templates/orders/components/ordering_step3.html
@@ -44,7 +44,7 @@
       <div class="flex items-center justify-between py-3">
         <!-- Last item, no bottom border -->
         <span class="text-sm text-gray-700">應付金額</span>
-        <span class="text-sm font-semibold text-gray-900">$ {{ total_price }}</span>
+        <span class="text-sm font-semibold text-gray-900">$ {{ cart.calculate_total_price }}</span>
       </div>
     </div>
 

--- a/templates/orders/show.html
+++ b/templates/orders/show.html
@@ -4,8 +4,11 @@
 <div class="flex flex-wrap">
   <!-- 左側訂單資訊 -->
   <div class="w-full md:w-1/2 p-4 border-r-[3px] border-r-[#ececec] border-dashed">
-    <div class="mb-4 py-3 text-white rounded-md flex justify-between items-center">{% include "components/order_status_badge.html" with order=order status=order.order_status %}</div>
-    {% include "components/store_info.html" with store=order.store %} {% include "components/pickup_number.html" with pickup_number=order.pickup_number %} {% include "components/order_info_table.html" with order=order %}
+    <div class="flex items-center space-x-2 mb-5">
+      <span class="text-2xl text-black font-bold"> 訂單狀態：</span>
+      <div id="order_status_display_{{ order.id }}">{% include 'shared/order/order_status_display.html' with order=order %}</div>
+    </div>
+    {% include "components/pickup_number.html" with pickup_number=order.pickup_number %} {% include "components/order_info_table.html" with order=order %}
   </div>
   <!-- 右側商品明細和操作按鈕 -->
   <div class="w-full md:w-1/2 p-4">
@@ -13,10 +16,7 @@
     <!-- 會員操作按鈕 -->
     <div class="space-y-3 mt-6">
       {% if order.order_status == 'PENDING' %}
-      <form action="{% url 'orders:cancel' order.id %}" method="post" class="w-full" onsubmit="return confirm('確定要取消訂單嗎？');">
-        {% csrf_token %}
-        <button type="submit" class="w-full bg-red-500 text-white px-4 py-3 rounded-lg hover:bg-red-600 transition-colors">取消訂單</button>
-      </form>
+      <div id="order_status_button_{{ order.id }}" class="flex gap-2 pt-2">{% include "shared/order/order_status_button.html" with order=order %}</div>
       {% endif %}
     </div>
   </div>

--- a/templates/shared/order/order_status_button.html
+++ b/templates/shared/order/order_status_button.html
@@ -1,0 +1,13 @@
+{% if request.user.is_authenticated and request.user.store %} {% if order.order_status == 'PENDING' or order.order_status == 'PREPARING' %}
+<button hx-post="{% url 'orders:cancel' order.id %}" hx-target="#order_status_button_{{ order.id }}" hx-swap="innerHTML" hx-confirm="確定要取消訂單嗎？" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500">取消訂單</button>
+{% endif %} {% if order.can_prepare %}
+<button hx-post="{% url 'orders:prepare' order.id %}" hx-target="#order_status_button_{{ order.id }}" hx-swap="innerHTML" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">開始準備</button>
+{% endif %} {% if order.can_mark_ready %}
+<button hx-post="{% url 'orders:mark_ready' order.id %}" hx-target="#order_status_button_{{ order.id }}" hx-swap="innerHTML" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">完成準備</button>
+{% endif %} {% if order.can_complete %}
+<button hx-post="{% url 'orders:complete' order.id %}" hx-target="#order_status_button_{{ order.id }}" hx-swap="innerHTML" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-800 hover:bg-green-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-700">完成取餐</button>
+{% endif %} {% endif %}
+<!-- prettier-ignore -->
+{% if request.user.is_authenticated and request.user.member %} {% if order.order_status == 'PENDING' %}
+<button hx-post="{% url 'orders:cancel' order.id %}" hx-target="#order_status_button_{{ order.id }}" hx-swap="innerHTML" hx-confirm="確定要取消訂單嗎？" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500">取消訂單</button>
+{% endif %} {% endif %}

--- a/templates/shared/order/order_status_display.html
+++ b/templates/shared/order/order_status_display.html
@@ -1,0 +1,3 @@
+{% load model_display %}
+
+<span class="inline-flex px-3 py-1 rounded-full text-sm font-medium {% if order.order_status == 'PENDING' %} bg-yellow-100 text-yellow-700 {% elif order.order_status == 'PREPARING' %} bg-blue-100 text-blue-700 {% elif order.order_status == 'READY' %} bg-emerald-100 text-emerald-700 {% elif order.order_status == 'COMPLETED' %} bg-green-100 text-green-700 {% elif order.order_status == 'NO_SHOW' %} bg-red-100 text-red-700 {% elif order.order_status == 'CANCELED' %} bg-slate-100 text-slate-600 {% elif order.order_status == 'CANCELED_REFUNDED' %} bg-red-50 text-red-600 {% endif %}"> {{ order|get_display:"order_status" }} </span>

--- a/templates/shared/order/partial_order_status_response.html
+++ b/templates/shared/order/partial_order_status_response.html
@@ -1,0 +1,8 @@
+<!-- 更新 flash message -->
+<div id="messages-container" hx-swap-oob="true">{% include "shared/messages.html" %}</div>
+
+<!-- 更新 order_status_display -->
+<div id="order_status_display_{{ order.id }}" hx-swap-oob="true">{% include "shared/order/order_status_display.html" with order=order %}</div>
+
+<!-- 更新 order_status_button -->
+<div id="order_status_button_{{ order.id }}" hx-swap-oob="true">{% include "shared/order/order_status_button.html" with order=order %}</div>

--- a/templates/stores/manage_orders.html
+++ b/templates/stores/manage_orders.html
@@ -33,7 +33,7 @@
             <p class="text-lg text-gray-500">訂單編號: {{ order.order_number }}</p>
             <p class="text-lg text-gray-500 font-bold">取餐編號: {{ order.pickup_number }}</p>
           </div>
-          <span class="inline-flex px-3 py-1 rounded-full text-sm font-medium {% if order.order_status == 'PENDING' %} bg-yellow-100 text-yellow-700 {% elif order.order_status == 'PREPARING' %} bg-blue-100 text-blue-700 {% elif order.order_status == 'READY' %} bg-emerald-100 text-emerald-700 {% elif order.order_status == 'COMPLETED' %} bg-green-100 text-green-700 {% elif order.order_status == 'NO_SHOW' %} bg-red-100 text-red-700 {% elif order.order_status == 'CANCELED' %} bg-slate-100 text-slate-600 {% elif order.order_status == 'CANCELED_REFUNDED' %} bg-red-50 text-red-600 {% endif %}"> {{ order|get_display:"order_status" }} </span>
+          <div id="order_status_display_{{ order.id }}">{% include 'shared/order/order_status_display.html' with order=order %}</div>
         </div>
       </div>
 
@@ -121,29 +121,7 @@
         </div>
 
         <!-- Action Buttons -->
-        <div class="flex gap-2 pt-2">
-          {% if order.order_status == 'PENDING' or order.order_status == 'PREPARING' %}
-          <form action="{% url 'orders:cancel' order.id %}" method="post" class="inline" onsubmit="return confirm('確定要取消訂單嗎？');">
-            {% csrf_token %}
-            <button type="submit" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500">取消訂單</button>
-          </form>
-          {% endif %} {% if order.can_prepare %}
-          <form action="{% url 'orders:prepare' order.id %}" method="post" class="inline">
-            {% csrf_token %}
-            <button type="submit" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">開始準備</button>
-          </form>
-          {% endif %} {% if order.can_mark_ready %}
-          <form action="{% url 'orders:mark_ready' order.id %}" method="post" class="inline">
-            {% csrf_token %}
-            <button type="submit" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">完成準備</button>
-          </form>
-          {% endif %} {% if order.can_complete %}
-          <form action="{% url 'orders:complete' order.id %}" method="post" class="inline">
-            {% csrf_token %}
-            <button type="submit" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-800 hover:bg-green-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-700">完成取餐</button>
-          </form>
-          {% endif %}
-        </div>
+        <div id="order_status_button_{{ order.id }}" class="flex gap-2 pt-2">{% include "shared/order/order_status_button.html" with order=order %}</div>
       </div>
     </div>
     {% empty %}


### PR DESCRIPTION
close #134 

* 商家訂單管理頁面和會員詳細訂單頁面，點擊「切換訂單狀態」的按鈕時，用 HTMX 實現局部更新


https://github.com/user-attachments/assets/a3b14461-6c57-4450-8e50-d4bb38d8beff



* 修正 ordering_step3.html 的 {{ total_price }} ， 改成 {{ cart.calculate_total_price }}