### PR TITLE
網址權限控管(商家及會員後台)

### DIFF
--- a/common/decorator.py
+++ b/common/decorator.py
@@ -29,9 +29,20 @@ def member_required(view_func):
             except Exception:
                 return redirect_with_message(req, 'members:new', '請先補充會員資料')
         else:
-            return redirect_with_message('users:index', '您不是會員，無法訪問此頁面')
+            return redirect_with_message(
+                req, 'users:index', '您不是會員，無法訪問此頁面'
+            )
 
-        return view_func(req, *args, **kwargs)
+        member_id = kwargs.get('id')
+
+        if member_id is not None and str(getattr(req.user.member, 'id', '')) == str(
+            member_id
+        ):
+            return view_func(req, *args, **kwargs)
+        else:
+            return redirect_with_message(
+                req, 'users:index', '你沒有權限存取其他會員後台的權限'
+            )
 
     return _wrapped_view
 
@@ -46,8 +57,21 @@ def store_required(view_func):
             except Exception:
                 return redirect_with_message(req, 'stores:new', '請先補充會員資料')
         else:
-            return redirect_with_message('users:index', '您不是會員，無法訪問此頁面')
+            return redirect_with_message(
+                req, 'users:index', '您不是會員，無法訪問此頁面'
+            )
 
-        return view_func(req, *args, **kwargs)
+        # return view_func(req, *args, **kwargs)
+
+        store_id = kwargs.get('id')  # 或 store_id，視你的 urls.py 而定
+
+        if store_id is not None and str(getattr(req.user.store, 'id', '')) == str(
+            store_id
+        ):
+            return view_func(req, *args, **kwargs)
+        else:
+            return redirect_with_message(
+                req, 'stores:index', '你沒有權限存取這個商家後台'
+            )
 
     return _wrapped_view

--- a/common/decorator.py
+++ b/common/decorator.py
@@ -33,13 +33,21 @@ def member_required(view_func):
                 req, 'users:index', '您不是會員，無法訪問此頁面'
             )
 
-        member_id = kwargs.get('id')
+        print('\n--- DEBUG: 權限檢查開始 ---')
+        print(
+            'DEBUG: 傳入的 kwargs:', kwargs
+        )  # <--- **新增這行，直接看 kwargs 裡有什麼**
 
-        if member_id is not None and str(getattr(req.user.member, 'id', '')) == str(
-            member_id
-        ):
+        # 從 kwargs 獲取 'id'
+        member_id_from_url = kwargs.get('id')
+
+        print("DEBUG: 從 kwargs.get('id') 獲取到的 member_id:", member_id_from_url)
+        print('DEBUG: 類型為:', type(member_id_from_url))
+
+        if member_id_from_url is None or str(getattr(req.user.member, 'id', '')) == str(member_id_from_url):
             return view_func(req, *args, **kwargs)
         else:
+            print('DEBUG: 權限檢查失敗！')
             return redirect_with_message(
                 req, 'users:index', '你沒有權限存取其他會員後台的權限'
             )


### PR DESCRIPTION
close #136 

**說明**
針對**商家**及**會員**進行權限的管制
防範他人透過網址進入**商家後台**及**會員後台**

**會員**
<img width="1440" alt="截圖 2025-05-29 上午10 41 09" src="https://github.com/user-attachments/assets/17c3d184-05ec-4efe-a55e-b8eb7c59d26c" />
<img width="1440" alt="截圖 2025-05-29 上午10 41 17" src="https://github.com/user-attachments/assets/66f22643-9fe6-4cde-bfc0-ef209fadea48" />


**商家**
<img width="1440" alt="截圖 2025-05-29 上午10 31 53" src="https://github.com/user-attachments/assets/6687e4e8-d194-455b-9abe-7e1222cdfb7b" />

<img width="1440" alt="截圖 2025-05-29 上午10 32 13" src="https://github.com/user-attachments/assets/04369f49-5979-4386-99b9-73b68a20db27" />
