### PR TITLE
通知訊息樣式更新

### DIFF
--- a/templates/shared/messages.html
+++ b/templates/shared/messages.html
@@ -1,29 +1,43 @@
+<!--自動淡出動畫提示訊息-->
 {% if messages %}
-<div x-data="{ show: true }" x-init="setTimeout(() => show = false, 3000)" x-show="show" x-transition>
+<div x-data="{ show: true }" x-init="setTimeout(() => show = false, 2000)" x-show="show" 
+  x-transition:enter="transition ease-out duration-300"
+  x-transition:enter-start="opacity-0 -translate-y-2"
+  x-transition:enter-end="opacity-100 translate-y-0"
+  x-transition:leave="transition ease-in duration-300"
+  x-transition:leave-start="opacity-100 translate-y-0"
+  x-transition:leave-end="opacity-0 translate-y-2"
+  class="fixed top-5 left-1/2 -translate-x-1/2 z-50 w-full max-w-sm px-4 transform-gpu">
+
+  <!-- 使用 Tailwind CSS 和 Alpine.js 來顯示訊息 -->
   <div class="fixed top-5 left-1/2 -translate-x-1/2 z-50 w-full max-w-sm px-4">
     {% for message in messages %}
-      {% with tag=message.tags|default:"info" %}
+      {% with tag=message.tags %}
       <div class="flex w-full overflow-hidden bg-white rounded-lg shadow-md dark:bg-gray-800 mb-2 border-l-4 
-        {% if 'success' in tag %}border-emerald-500{% elif 'error' in tag %}border-red-500{% elif 'warning' in tag %}border-yellow-500{% else %}border-blue-500{% endif %}">
+        {% if 'success' in tag %}
+        border-emerald-500
+        {% elif 'error' in tag %}
+        border-red-500
+        {% endif %}">
         
+        <!--左側圖示背景-->
         <div class="flex items-center justify-center w-12 
           {% if 'success' in tag %}bg-emerald-500
           {% elif 'error' in tag %}bg-red-500
-          {% elif 'warning' in tag %}bg-yellow-500
-          {% else %}bg-blue-500{% endif %}">
+          {% endif %}">
           <!-- 可根據 tag 改變 icon -->
           <svg class="w-6 h-6 text-white fill-current" viewBox="0 0 40 40">
             <path d="M20 3.33331C10.8 3.33331 3.33337 10.8 3.33337 20C3.33337 29.2 10.8 36.6666 20 36.6666C29.2 36.6666 36.6667 29.2 36.6667 20C36.6667 10.8 29.2 3.33331 20 3.33331ZM16.6667 28.3333L8.33337 20L10.6834 17.65L16.6667 23.6166L29.3167 10.9666L31.6667 13.3333L16.6667 28.3333Z"/>
           </svg>
         </div>
 
+        <!--右側訊息內容-->
         <div class="px-4 py-2 -mx-3">
           <div class="mx-3">
             <span class="font-semibold capitalize 
               {% if 'success' in tag %}text-emerald-500
               {% elif 'error' in tag %}text-red-500
-              {% elif 'warning' in tag %}text-yellow-500
-              {% else %}text-blue-500{% endif %}">
+              {% endif %}">
               {{ tag }}
             </span>
             <p class="text-sm text-gray-600 dark:text-gray-200">{{ message }}</p>

--- a/templates/shared/messages.html
+++ b/templates/shared/messages.html
@@ -1,9 +1,37 @@
 {% if messages %}
-<div class="fixed top-5 left-1/2 -translate-x-1/2 z-20 w-fit max-w-sm px-4">
-  {% for message in messages %}
-  <div x-data="{show: true}" x-init="setTimeout(() => show = false, 2000)" x-show="show" x-transition class="alert alert-{{ message.tags }}">
-    <span>{{ message }}</span>
+<div x-data="{ show: true }" x-init="setTimeout(() => show = false, 3000)" x-show="show" x-transition>
+  <div class="fixed top-5 left-1/2 -translate-x-1/2 z-50 w-full max-w-sm px-4">
+    {% for message in messages %}
+      {% with tag=message.tags|default:"info" %}
+      <div class="flex w-full overflow-hidden bg-white rounded-lg shadow-md dark:bg-gray-800 mb-2 border-l-4 
+        {% if 'success' in tag %}border-emerald-500{% elif 'error' in tag %}border-red-500{% elif 'warning' in tag %}border-yellow-500{% else %}border-blue-500{% endif %}">
+        
+        <div class="flex items-center justify-center w-12 
+          {% if 'success' in tag %}bg-emerald-500
+          {% elif 'error' in tag %}bg-red-500
+          {% elif 'warning' in tag %}bg-yellow-500
+          {% else %}bg-blue-500{% endif %}">
+          <!-- 可根據 tag 改變 icon -->
+          <svg class="w-6 h-6 text-white fill-current" viewBox="0 0 40 40">
+            <path d="M20 3.33331C10.8 3.33331 3.33337 10.8 3.33337 20C3.33337 29.2 10.8 36.6666 20 36.6666C29.2 36.6666 36.6667 29.2 36.6667 20C36.6667 10.8 29.2 3.33331 20 3.33331ZM16.6667 28.3333L8.33337 20L10.6834 17.65L16.6667 23.6166L29.3167 10.9666L31.6667 13.3333L16.6667 28.3333Z"/>
+          </svg>
+        </div>
+
+        <div class="px-4 py-2 -mx-3">
+          <div class="mx-3">
+            <span class="font-semibold capitalize 
+              {% if 'success' in tag %}text-emerald-500
+              {% elif 'error' in tag %}text-red-500
+              {% elif 'warning' in tag %}text-yellow-500
+              {% else %}text-blue-500{% endif %}">
+              {{ tag }}
+            </span>
+            <p class="text-sm text-gray-600 dark:text-gray-200">{{ message }}</p>
+          </div>
+        </div>
+      </div>
+      {% endwith %}
+    {% endfor %}
   </div>
-  {% endfor %}
 </div>
 {% endif %}


### PR DESCRIPTION
close #209 

**說明**
1. 更新訊息樣式，並針對成功及錯誤做訊息的區辨
2. 訊息擺放位置調整至中間


***成功訊息***
<img width="1440" alt="截圖 2025-06-05 凌晨12 08 45" src="https://github.com/user-attachments/assets/145cda9f-d1ca-46d1-a34a-6be63ee15ab4" />

<img width="1440" alt="截圖 2025-06-05 凌晨12 08 53" src="https://github.com/user-attachments/assets/65ca5a2b-37f2-4c23-a804-9e39e79d92be" />

***失敗訊息***
<img width="1440" alt="截圖 2025-06-05 凌晨12 08 33" src="https://github.com/user-attachments/assets/55a00fc4-851a-4494-8ccb-0951c6488034" />
