### PR TITLE
購物車計算總價和數量用資料庫計算

### DIFF
--- a/carts/views.py
+++ b/carts/views.py
@@ -91,7 +91,7 @@ def update_cart_item(req, item_id):
             cart_item.save()
     except Exception:
         messages.error(req, '購物車更新失敗')
-    innertext = f'{cart.calculate_total_price}'
+    innertext = f'{cart.total_price}'
     messages_html = render_to_string(
         'shared/messages.html', {'messages': get_messages(req)}
     )
@@ -177,8 +177,8 @@ def delete_item_from_ordering(req, id):
         return response
 
     # 若還有商品，則更新總數與金額
-    total_quantity = cart.calculate_total_quantity
-    total_price = cart.calculate_total_price
+    total_quantity = cart.total_quantity
+    total_price = cart.total_price
 
     messages.success(req, f'成功刪除 {product_name}')
     messages_html = render_to_string(

--- a/templates/carts/index.html
+++ b/templates/carts/index.html
@@ -23,7 +23,7 @@
         <h2 class="text-lg font-medium text-[#3a643a] truncate">{{ cart.store.name }}</h2>
       </div>
 
-      <p class="text-sm text-gray-600 mb-4">總金額： <span class="font-semibold text-black">{{ cart.calculate_total_price }}</span> 元</p>
+      <p class="text-sm text-gray-600 mb-4">總金額： <span class="font-semibold text-black">{{ cart.total_price }}</span> 元</p>
 
       <div class="mt-auto">
         <a href="{% url 'carts:show' cart.id %}" class="block w-full text-center bg-[#5a855a] text-white py-1.5 rounded-md hover:bg-[#2e4e2e] transition-colors mb-2">查看明細</a>

--- a/templates/carts/show.html
+++ b/templates/carts/show.html
@@ -64,7 +64,7 @@
 <!-- 總金額區塊 -->
 <div class="mt-8 flex flex-col md:flex-row md:items-center md:justify-between">
   <div class="text-lg font-semibold text-right md:text-left mb-4 md:mb-0">
-    總金額：<span id="totalPrice">{{ cart.calculate_total_price }}</span> 元
+    總金額：<span id="totalPrice">{{ cart.total_price }}</span> 元
   </div>
 
   <!-- Alpine 包裹區塊 -->

--- a/templates/orders/components/ordering_step1.html
+++ b/templates/orders/components/ordering_step1.html
@@ -87,12 +87,12 @@
       </div>
       <div id="cart-summary-section" class="space-y-2 p-4">
         <div class="flex justify-between text-sm text-gray-700">
-          <span id="ordering_total_quantity">商品 X {{ cart.calculate_total_quantity }}</span>
-          <span id="ordering_total_price_brief">$ {{ cart.calculate_total_price }}</span>
+          <span id="ordering_total_quantity">商品 X {{ cart.total_quantity }}</span>
+          <span id="ordering_total_price_brief">$ {{ cart.total_price }}</span>
         </div>
         <div class="flex justify-between text-sm font-semibold text-gray-800">
           <span>應付金額</span>
-          <span id="ordering_total_price_final">$ {{ cart.calculate_total_price }}</span>
+          <span id="ordering_total_price_final">$ {{ cart.total_price }}</span>
         </div>
       </div>
     </div>

--- a/templates/orders/components/ordering_step2.html
+++ b/templates/orders/components/ordering_step2.html
@@ -15,10 +15,10 @@
     <!-- Total Amount Bar -->
     <div class="mb-6 flex items-center justify-between rounded-md bg-blue-700 p-3 text-white m-auto mt-7">
       <div class="flex items-center">
-        <span class="mr-3 rounded-md bg-white px-3 py-1 text-sm font-semibold text-blue-700"> {{ cart.calculate_total_quantity }}份</span>
+        <span class="mr-3 rounded-md bg-white px-3 py-1 text-sm font-semibold text-blue-700"> {{ cart.total_quantity }}份</span>
         <span class="text-base font-semibold">應付金額</span>
       </div>
-      <span class="text-lg font-bold">$ {{ cart.calculate_total_price }}</span>
+      <span class="text-lg font-bold">$ {{ cart.total_price }}</span>
     </div>
 
     <!-- Recipient Information -->

--- a/templates/orders/components/ordering_step3.html
+++ b/templates/orders/components/ordering_step3.html
@@ -44,7 +44,7 @@
       <div class="flex items-center justify-between py-3">
         <!-- Last item, no bottom border -->
         <span class="text-sm text-gray-700">應付金額</span>
-        <span class="text-sm font-semibold text-gray-900">$ {{ cart.calculate_total_price }}</span>
+        <span class="text-sm font-semibold text-gray-900">$ {{ cart.total_price }}</span>
       </div>
     </div>
 


### PR DESCRIPTION
close #214 


# 修改內容

 重構 `Cart.calculate_total_price` 與 `Cart.calculate_total_quantity` 兩個屬性方法

* @property 是屬性，把  `Cart.calculate_total_price` 與 `Cart.calculate_total_quantity` 分別改成 `Cart.total_price` 跟 `Cart.total_quantity`

* 將原本使用 Python `for` 迴圈計算總價與總量的邏輯，改為使用 Django ORM 的 `.aggregate()` 方法：

  * 使用 `Sum(F('quantity') * F('product__price'))` 計算總價
  * 使用 `Sum('quantity')` 計算總量

* 加入 `or 0` 以避免當無項目時回傳 `None`

# 重構效果

* 提升效能，將計算邏輯交由資料庫處理，減少應用層資源消耗
* 避免潛在的 N+1 問題
* 提升程式可讀性與維護性

