### PR TITLE
商家訂單編號與取餐編號重構

### DIFF
--- a/orders/utils.py
+++ b/orders/utils.py
@@ -1,5 +1,8 @@
 from datetime import timedelta
 
+from django.db import connection
+from django.utils.timezone import localtime, now
+
 
 def next_10min(datetime):
     """
@@ -18,3 +21,54 @@ def next_10min(datetime):
     if remainder != 0:
         datetime += timedelta(minutes=(10 - remainder))
     return datetime.replace(second=0, microsecond=0)
+
+
+def get_order_number():
+    date_str = localtime(now()).strftime('%Y%m%d')
+    seq_name = f'order_seq_{date_str}'
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_class WHERE relname = %s
+                ) THEN
+                    CREATE SEQUENCE {seq_name} START 1;
+                END IF;
+            END
+            $$;
+        """,
+            [seq_name],
+        )
+
+        cursor.execute(f"SELECT nextval('{seq_name}')")
+        next_val = cursor.fetchone()[0]
+        return f'ORD{date_str}{next_val:06d}'
+
+
+def get_pickup_number(store_id):
+    short_id = str(store_id).replace('-', '')[:8]
+    date_str = localtime(now()).strftime('%Y%m%d')
+    seq_name = f'pickup_seq_{short_id}_{date_str}'
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_class WHERE relname = %s
+                ) THEN
+                    CREATE SEQUENCE {seq_name} START 1;
+                END IF;
+            END
+            $$;
+        """,
+            [seq_name],
+        )
+
+        cursor.execute(f"SELECT nextval('{seq_name}')")
+        next_val = cursor.fetchone()[0]
+        return f'{(next_val - 1) % 9999 + 1:04d}'


### PR DESCRIPTION
close #169 

# 改用 PostgreSQL Sequence 產生訂單編號與取餐編號

# 調整內容

* 新增使用 PostgreSQL 的 `sequence` 機制來產生：

  * `order_number`（格式：`ORDYYYYMMDD000001`）
  * `pickup_number`（格式：`0001`，依商店及當天歸零）
* 每日（依日期字串）建立對應的 sequence，自動從 1 開始。
* 避免過往在高併發下產生重複編號的問題。

---

# 為什麼不使用 `last + 1` 或 `count + 1`？

在原本的實作中，使用：

* `Order.objects.filter(...).last()` → 取得最後一筆編號，再加 1
* 或 `count()` 當作流水號

這些做法在 **高併發** 場景下存在以下問題：

1. **競爭條件（Race Condition）**
   多個請求同時進來時，可能會讀到相同的 last 或 count 值，在寫入前產生相同的編號，導致編號衝突或 IntegrityError。

2. **效率與一致性問題**
   每次都需對資料庫進行排序、計數，當資料筆數增加時，會拖慢效能，也可能因交易未 commit 而取得不一致資料。

---

# 使用 PostgreSQL Sequence 的優點

1. **具原子性與併發安全性**
   使用 `nextval('sequence_name')` 由資料庫保證每次取得的數值唯一且自動遞增，避免重複。

2. **效能更佳**
   不需要依賴查詢資料表內容，只讀取 sequence 值即可完成編號。

3. **可每日重置（根據日期建立 sequence 名稱）**
   每天建立新序列（如：`order_seq_20250606`），確保每日從 000001 開始。

4. **支援多商店**
   針對取餐編號，可為每家商店每日建立一組 sequence，例如：`pickup_seq_store123_20250606`，讓每家店的取餐編號從 0001 起跳，避免跨店編號混淆。

---

如有後續需求，也能搭配 Django 的 signals 或定時任務（如 Celery）自動清理舊的 sequence。
