### PR TITLE
修正navbar被畫面內容遮住的問題

### DIFF
--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -1,5 +1,5 @@
 {% extends "layouts/default.html" %} {% block main %}
-<div class="bg-white">
+<div>
   <div class="relative z-0 isolate px-6 pt-14 lg:px-8">
     <div class="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl pointer-events-none sm:-top-80" aria-hidden="true">
       <div class="relative left-[calc(50%-11rem)] aspect-1155/678 w-144.5 -translate-x-1/2 rotate-30 bg-gradient-to-tr from-[#A8E6A2] to-[#3A8D3D] opacity-30 sm:left-[calc(50%-30rem)] sm:w-288.75" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>


### PR DESCRIPTION
close #223 

**說明**
原本navbar中間部分被中間內容遮罩住了，經調整後問題已改善。
改善狀況如下圖：


<img width="1292" alt="截圖 2025-06-06 下午4 00 30" src="https://github.com/user-attachments/assets/88df7317-a6c5-4d95-a8ce-b4b1a2071c09" />
