### PR TITLE
新增products異動訊息提醒

### DIFF
--- a/products/views.py
+++ b/products/views.py
@@ -1,3 +1,4 @@
+from django.contrib import messages
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.http import require_POST
 
@@ -69,6 +70,7 @@ def create(request, category_id):
             Category.objects.prefetch_related('products'), id=category_id
         )
         products = category.products.filter(store=request.user.store)
+        messages.success(request, f'商品 {form.name} 已新增')
         return render(
             request,
             'shared/business/products/create_success.html',
@@ -99,11 +101,12 @@ def update(request, id):
         form = form.save(commit=False)
         # form.store = request.user.store
         form.save()
+        messages.success(request, f'商品 {product.name} 已更新')
         category = product.category
         products = Product.objects.prefetch_related('category').filter(
             category=category, store=request.user.store
         )
-        return render(
+        return redirect(
             request,
             'shared/business/products/create_success.html',
             {'products': products, 'category': category},
@@ -122,7 +125,8 @@ def delete(request, id):
     products = Product.objects.prefetch_related('category').filter(
         category=category, store=request.user.store
     )
-    return render(
+    messages.success(request, f'商品 {product.name} 已刪除')
+    return redirect(
         request,
         'stores/business/product_list.html',
         {'products': products, 'category': category},

--- a/products/views.py
+++ b/products/views.py
@@ -30,6 +30,7 @@ def index(request):
     )
 
 
+@store_required
 def new(request, category_id):
     store = request.user.store
     category = get_object_or_404(Category, id=category_id)
@@ -53,7 +54,6 @@ def show(request, id):
         'products/show.html',
         {
             'product': product,
-            'quantity_range': range(1, 101),
         },
     )
 
@@ -98,15 +98,13 @@ def update(request, id):
     product = get_object_or_404(Product, pk=id)
     form = ProductForm(request.POST, request.FILES, instance=product)
     if form.is_valid():
-        form = form.save(commit=False)
-        # form.store = request.user.store
         form.save()
         messages.success(request, f'商品 {product.name} 已更新')
         category = product.category
         products = Product.objects.prefetch_related('category').filter(
             category=category, store=request.user.store
         )
-        return redirect(
+        return render(
             request,
             'shared/business/products/create_success.html',
             {'products': products, 'category': category},
@@ -118,6 +116,7 @@ def update(request, id):
     )
 
 
+@store_required
 def delete(request, id):
     product = get_object_or_404(Product, pk=id)
     category = product.category
@@ -126,9 +125,9 @@ def delete(request, id):
         category=category, store=request.user.store
     )
     messages.success(request, f'商品 {product.name} 已刪除')
-    return redirect(
+    return render(
         request,
-        'stores/business/product_list.html',
+        'shared/business/products/create_success.html',
         {'products': products, 'category': category},
     )
 

--- a/templates/shared/business/products/create_success.html
+++ b/templates/shared/business/products/create_success.html
@@ -1,1 +1,2 @@
 <div id="product-list" class="w-full md:w-3/4 space-y-6" hx-swap-oob="outerHTML">{% include "stores/business/product_list.html" with category=category products=products%}</div>
+<div id="messages-container" hx-swap-oob="true">{% include "shared/messages.html" %}</div>


### PR DESCRIPTION
close #231 

**說明**
products異動成功後，會跳出訊息告知此動作已執行成功


6/9更新 ->更新標籤樣式
<img width="859" alt="截圖 2025-06-09 下午4 17 15" src="https://github.com/user-attachments/assets/6c6b11d2-38eb-453e-b3c1-3ced7591cbde" />



----------6/8更新
1.新增
<img width="1416" alt="截圖 2025-06-08 下午3 01 00" src="https://github.com/user-attachments/assets/73a43fc7-4fba-443b-88d8-a30a21e8a426" />

2.更新
![截圖 2025-06-08 下午3 00 33](https://github.com/user-attachments/assets/44321b42-28e5-4955-bb2c-f025d4c6a114)
3.刪除
<img width="1385" alt="截圖 2025-06-08 下午3 02 10" src="https://github.com/user-attachments/assets/93e31dff-dfd9-41f3-8155-18ff496ce28b" />
