### PR TITLE
修正 member 不能編輯的 error

### DIFF
--- a/members/views.py
+++ b/members/views.py
@@ -44,7 +44,7 @@ def show(request, id):
         form = MemberForm(request.POST, instance=member)
         if form.is_valid():
             form.save()
-            return redirect('members:show')
+            return redirect('members:show', member.id)
         return render(request, 'members/edit.html', {'member': member, 'form': form})
     return render(request, 'members/index.html', {'member': member})
 


### PR DESCRIPTION
目前 member 編輯後按下編輯按鈕會有錯誤

修正:

member views.py
```python
@member_required
def show(request, id):
    member = get_object_or_404(Member, pk=id, user=request.user)
    if request.method == 'POST':
        form = MemberForm(request.POST, instance=member)
        if form.is_valid():
            form.save()
            return redirect('members:show')
            ....
```

裡的 `return redirect('members:show')` 改成 `return redirect('members:show', member.id)`