### PR TITLE
修正 line pay 付款時 line message 沒顯示詳細商品跟總價格資訊的問題

### DIFF
--- a/orders/signals.py
+++ b/orders/signals.py
@@ -66,7 +66,6 @@ def send_line_message_when_order_created(sender, instance, created, **kwargs):
 
 @receiver(post_save, sender=Order)
 def handle_order_notifications(sender, instance, created, **kwargs):
-    """處理訂單通知"""
     if created:  # 新訂單由另一個 signal 處理
         return
 

--- a/orders/utils.py
+++ b/orders/utils.py
@@ -115,7 +115,7 @@ def build_line_order_created_message(order):
         f'🏪 店家：{order.store_name}',
         f'📞 店家電話：{order.store_phone}',
         f'🔢 取餐號碼：{order.pickup_number}',
-        f'📅 取餐時間：{order.pickup_time.strftime("%Y-%m-%d %H:%M")}',
+        f'📅 取餐時間：{localtime(order.pickup_time).strftime("%Y-%m-%d %H:%M")}',
         '',
         '📦 商品內容：',
     ]
@@ -123,7 +123,7 @@ def build_line_order_created_message(order):
     total = 0
     for item in order.orderitem_set.all():
         lines.append(
-            f'- {item.product_name} x {item.quantity}（{item.unit_price} 元）= {item.subtotal:.0f} 元'
+            f'- {item.product_name}（{item.unit_price} 元）x {item.quantity} = {item.subtotal:.0f} 元'
         )
         total += item.subtotal
 
@@ -139,12 +139,19 @@ def build_line_order_status_message(order):
     if order.order_status == OrderStatus.CANCELED:
         # 根據取消來源建立不同訊息
         if order.canceled_by == CancelBy.MEMBER:
-            lines.extend([f'❌ 您已取消訂單 #{order.order_number}'])
+            lines.extend(
+                [
+                    f'❌ 您已取消訂單 #{order.order_number}',
+                    '感謝您的光臨，歡迎再次訂購！',
+                ]
+            )
         elif order.canceled_by == CancelBy.STORE:
             lines.extend(
                 [
-                    f'❌ 很抱歉，店家已取消您的訂單 #{order.order_number}\n'
-                    '如有疑問請直接聯繫店家'
+                    f'❌ 很抱歉，{order.store_name}已取消您的訂單 #{order.order_number}\n'
+                    '如有疑問請直接聯繫{order.store_name}',
+                    '電話：{order.store_phone}',
+                    '感謝您的光臨，歡迎再次訂購！',
                 ]
             )
         elif order.canceled_by == CancelBy.SYSTEM:
@@ -152,6 +159,7 @@ def build_line_order_status_message(order):
                 [
                     f'❌ 您的訂單 #{order.order_number} 已被系統自動取消\n'
                     '原因：超過取餐時間未取餐',
+                    '感謝您的光臨，歡迎再次訂購！',
                 ]
             )
 


### PR DESCRIPTION
close #250 

line messsage 是在 signal post_save orders 時觸發的

在 line pay  confirm 函數裡是先存 Order 再建立 OrderItem
計算總價格也是在建立 OrderItem 時計算的
因此 line message 裡的詳細商品跟總價格資訊是空的

修正：
* 在 建立 OrderItem 後才儲存 Order
* 修改 line message 的回覆訊息