### PR TITLE
調整登入/建立member後的轉址

### DIFF
--- a/members/views.py
+++ b/members/views.py
@@ -23,7 +23,8 @@ def create_member(request):
             member = form.save(commit=False)
             member.user = request.user
             member.save()
-            return redirect('members:index')
+            next_url = request.POST.get('next')
+            return redirect(next_url or 'members:show', id=member.id)
         else:
             messages.error(request, '請檢查輸入內容')
             return render(request, 'members/new.html', {'form': form}, status=400)

--- a/templates/members/new.html
+++ b/templates/members/new.html
@@ -2,7 +2,7 @@
 
 <form method="POST" action="{% url 'members:create_member' %}" class="max-w-xl mx-auto bg-white text-black p-6 mt-10 rounded-2xl shadow-lg">
   {% csrf_token %}
-
+  <input type="hidden" name="next" value="{{ request.GET.next|default:request.META.HTTP_REFERER }}" />
   <h2 class="text-2xl font-semibold mb-4 border-b pb-2 border-gray-200">編輯會員資料</h2>
 
   <div class="flex flex-col items-center mb-6">

--- a/templates/users/sign_in.html
+++ b/templates/users/sign_in.html
@@ -14,7 +14,7 @@
     {% csrf_token %} {% if error %}
     <p class="text-red-500 text-sm text-center">{{ error }}</p>
     {% endif %}
-
+    <input x-data type="hidden" name="next" :value="window.location.href" />
     <div>
       <label for="email" class="block text-sm font-medium">電子郵件：</label>
       <input type="email" name="email" placeholder="example@gmail.com" class="w-full border px-3 py-2 rounded mt-1" />

--- a/templates/users/sign_up.html
+++ b/templates/users/sign_up.html
@@ -9,6 +9,7 @@
 
     <p class="text-center text-sm">Fit Your Calories, Fit Your Life!</p>
     <form method="post" hx-post="{% url 'users:create_user' %}" hx-target="#signupModal" hx-swap="innerHTML" class="space-y-3 mt-4">
+      <input x-data type="hidden" name="next" :value="window.location.href" />
       <div class="mb-1 relative">
         <label for="email" class="block text-sm font-medium">電子郵件：</label>
         <input type="email" name="email" value="{{ userform.email.value }}" placeholder="example@gmail.com" class="w-full border px-3 py-1.5 rounded mt-1" />

--- a/users/views.py
+++ b/users/views.py
@@ -72,7 +72,8 @@ def create_user(req):
             'useremail': user.email,  # 對應 template 的變數
         }
         message.send()
-        return create_session(req)
+        next_url = req.POST.get('next') or '/stores/'
+        return create_session(req, next_url)
     else:
         return render(
             req,
@@ -135,7 +136,7 @@ def sign_in_store(req):
 
 # 登入處理（會員）
 @require_POST
-def create_session(req):
+def create_session(req, next_url=None):
     email = req.POST.get('email')
     password = req.POST.get('password')
     # 因為上方create_user有用到這隻function，但是在註冊的時候沒有‘password’欄位，
@@ -152,8 +153,10 @@ def create_session(req):
     login(req, user)
     if user.is_member:
         messages.success(req, '會員登入成功！')
+    if not next_url:
+        next_url = req.POST.get('next') or '/stores/'  # 預設跳 stores 頁
     response = HttpResponse()
-    response['HX-Redirect'] = '/stores/'
+    response['HX-Redirect'] = next_url
     return response
 
 


### PR DESCRIPTION
close #271 

重設登入，建立會員資料後的轉址
轉向前一個瀏覽器url，但是不會延續之前的動作：
- 沒有會員資料的時候點擊加入收藏按鈕會跳轉至建立會員資料的頁面，在完成後僅跳轉回原本的商家頁面