### PR TITLE
修正手機版時間選擇器不能用 Flatpickr 的問題

### DIFF
--- a/orders/forms.py
+++ b/orders/forms.py
@@ -33,8 +33,10 @@ class OrderForm(ModelForm):
         widgets = {
             'pickup_time': DateTimeInput(
                 attrs={
-                    'type': 'datetime-local',
+                    'type': 'text',
+                    'class': 'flatpickr-input',
                 },
+                format='%Y-%m-%dT%H:%M',
             )
         }
 

--- a/src/scripts/datePicker.js
+++ b/src/scripts/datePicker.js
@@ -1,0 +1,13 @@
+import { initPickupTimePicker } from './flatpickr/main.js';
+
+export const DatePicker = () => ({
+  init() {
+    initPickupTimePicker('#id_pickup_time', 'healthy_style');
+    initPickupTimePicker('#id_date_of_birth', 'healthy_style', {
+      enableTime: false,
+      dateFormat: 'Y-m-d',
+      altFormat: 'Y年m月d日',
+      altInput: true,
+    });
+  },
+});

--- a/src/scripts/flatpickr/init.js
+++ b/src/scripts/flatpickr/init.js
@@ -36,7 +36,7 @@ class StyledFlatpickr {
       altFormat: 'Y年m月d日',
       scrollInput: true,
       shorthandCurrentMonth: true,
-      locale: 'zh_tw',
+      disableMobile: true,
       minDate,
       maxDate,
       onReady: (selectedDates, dateStr, instance) => {

--- a/src/scripts/input.js
+++ b/src/scripts/input.js
@@ -3,7 +3,7 @@ import { Chart, registerables } from 'chart.js';
 import flatpickr from 'flatpickr';
 import htmx from 'htmx.org';
 import cartItem from './carts/cartItemEdit.js';
-import { initPickupTimePicker } from './flatpickr/main.js';
+import { DatePicker } from './datePicker.js';
 import { searchFormComponent } from './searchForm.js';
 import { initCategorySort } from './stores/categorySort.js';
 import { initProductSort } from './stores/productSort.js';
@@ -18,13 +18,7 @@ window.htmx = htmx;
 window.flatpickr = flatpickr;
 window.searchFormComponent = searchFormComponent;
 
-initPickupTimePicker('#id_pickup_time', 'healthy_style');
-initPickupTimePicker('#id_date_of_birth', 'healthy_style', {
-  enableTime: false,
-  dateFormat: 'Y-m-d',
-  altFormat: 'Y年m月d日',
-  altInput: true,
-});
+Alpine.data('dataPicker', DatePicker);
 
 window.cartItem = cartItem;
 

--- a/templates/members/edit.html
+++ b/templates/members/edit.html
@@ -9,7 +9,7 @@
     <img src="https://5x-fitcal.s3.ap-northeast-1.amazonaws.com/media/default/member-logo.webp" alt="頭像" class="w-32 h-32 object-cover rounded-full mb-4 border border-black" />
   </div>
 
-  <div class="space-y-4">
+  <div x-data="dataPicker" x-init="init" class="space-y-4">
     {% for field in form %}
     <div>
       <label class="block font-medium text-gray-700 mb-1" for="{{ field.id_for_label }}"> {{ field.label }} </label>

--- a/templates/orders/components/ordering_step1.html
+++ b/templates/orders/components/ordering_step1.html
@@ -54,7 +54,7 @@
         </div>
 
         <div class="flex flex-col gap-4">
-          <div class="mb-4 flex items-center">
+          <div x-data="dataPicker" x-init="init" class="mb-4 flex items-center">
             <div class="mr-2 flex h-8 w-8 items-center justify-center rounded-full bg-[#5a855a] text-white">
               <i class="fa-regular fa-clock"></i>
             </div>


### PR DESCRIPTION
close #274 

問題：在部分行動裝置（如 iOS Safari / Android Chrome）中，input[type="datetime-local"] 會觸發原生時間選擇器，導致 Flatpickr 的 UI 被遮蓋或無法使用

解法：使用 type="text"，完全交由 Flatpickr 呈現時間選擇介面

![image](https://github.com/user-attachments/assets/1b2abae2-53a8-4924-b35f-1e088519df3a)

![image](https://github.com/user-attachments/assets/000395ea-81aa-4ef8-882a-babab6e13492)
