### PR TITLE
B 端訂單管理頁面切版修正 

### DIFF
--- a/templates/shared/orders/_order_list_table.html
+++ b/templates/shared/orders/_order_list_table.html
@@ -9,7 +9,7 @@
 
   <!-- Table wrapper with horizontal scroll -->
   <div class="overflow-x-auto bg-white rounded-lg shadow border border-gray-200">
-    <table class="min-w-full divide-y divide-gray-200 whitespace-nowrap lg:whitespace-normal">
+    <table class="min-w-full divide-y divide-gray-200 whitespace-nowrap">
       <thead class="bg-gray-50 text-sm font-semibold text-gray-700">
         <tr class="text-center">
           <th class="px-4 py-3 sticky left-0 bg-gray-50 w-36">訂單編號</th>

--- a/templates/stores/orders.html
+++ b/templates/stores/orders.html
@@ -1,6 +1,6 @@
 {% extends 'layouts/business/default.html' %} {% block main %}
 
-<div class="max-w-5xl mx-auto px-4 py-6">
+<div class="container mx-auto px-4 py-6">
   <!-- Tabs -->
   <div id="order-tabs">{% include "shared/orders/order_tab_bar.html" %}</div>
 


### PR DESCRIPTION
close #276 

預約訂單跟歷史訂單是以 table 方式呈現

原本 table 裡有些欄位會有換行的情形，改成加大 table 寬度，避免內容有換行的情形

table 寬度加大，內容沒有出現換行的情形
![image](https://github.com/user-attachments/assets/3a5ac694-a6e4-4c3e-be2d-42d6c0e6f325)
