### PR TITLE
修正 全站基礎字體大小 & main區塊padding & 購物車商家背景及圖片顯示異常

### DIFF
--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -8,6 +8,9 @@
 @import './components/stepper.css';
 
 @layer base {
+  html {
+    font-size: 20px;
+  }
   button {
     @apply cursor-pointer;
   }

--- a/templates/carts/index.html
+++ b/templates/carts/index.html
@@ -6,8 +6,8 @@
   {% for cart in carts %}
   <div class="bg-white shadow-md rounded-lg overflow-hidden flex flex-col justify-between">
     <!-- 商家橫幅圖片 -->
-    {% if cart.store.banner %}
-    <img src="{{ cart.store.banner.url }}" alt="商家橫幅" class="w-full h-24 object-cover" />
+    {% if cart.store.cover_url %}
+    <img src="{{ cart.store.cover_url }}" alt="商家橫幅" class="w-full h-24 object-cover" />
     {% else %}
     <div class="w-full h-24 bg-gray-200 flex items-center justify-center text-gray-400 text-sm">無橫幅圖片</div>
     {% endif %}
@@ -15,8 +15,8 @@
     <!-- 商家資訊區塊 -->
     <div class="p-4 flex flex-col flex-1">
       <div class="flex items-center mb-2">
-        {% if cart.store.logo %}
-        <img src="{{ cart.store.logo.url }}" alt="商家Logo" class="w-10 h-10 rounded-full object-cover mr-2 border border-gray-300" />
+        {% if cart.store.logo_url %}
+        <img src="{{ cart.store.logo_url }}" alt="商家Logo" class="w-10 h-10 rounded-full object-cover mr-2 border border-gray-300" />
         {% else %}
         <div class="w-10 h-10 bg-gray-200 rounded-full flex items-center justify-center text-sm text-gray-500 mr-2">無</div>
         {% endif %}

--- a/templates/layouts/default.html
+++ b/templates/layouts/default.html
@@ -14,7 +14,7 @@
   <body class="min-h-screen flex flex-col" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
     <main class="flex-1">
       <nav class="shadow-sm fixed top-0 left-0 w-full z-50 bg-white">{% include 'shared/navbar.html' %}</nav>
-      <section class="max-w-7xl mx-auto mt-33 md:mt-17">
+      <section class="max-w-7xl px-2 mx-auto mt-33 md:mt-17">
         <div id="messages-container">{% include "shared/messages.html" %}</div>
         {% include "chatbot/widget.html" %} {% block main %}{% endblock main %}
       </section>


### PR DESCRIPTION
close #278 
- 設定全站基礎字體大小20px
- 設定main區塊的px-2，兩側保留一些空間，使用者體驗較好
- 修正購物車頁面商家cover和logo不顯示問題