### PR TITLE
建立訂單時依據商家營業時間調整取貨時間

### DIFF
--- a/orders/forms.py
+++ b/orders/forms.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from django.core.exceptions import ValidationError
 from django.forms import DateTimeInput, ModelForm, NumberInput
@@ -41,6 +41,7 @@ class OrderForm(ModelForm):
         }
 
     def __init__(self, *args, **kwargs):
+        self.store = kwargs.pop('store', None)
         self.mode = kwargs.pop('mode', 'create')
         super().__init__(*args, **kwargs)
 
@@ -60,7 +61,7 @@ class OrderForm(ModelForm):
         rounded_time = next_10min(now)
 
         if self.mode == 'create':
-            self.fields['pickup_time'].initial = rounded_time
+            self.fields['pickup_time'].initial = self._get_next_valid_time(rounded_time)
 
             self.fields.pop('order_status')
             self.fields.pop('payment_status')
@@ -86,6 +87,27 @@ class OrderForm(ModelForm):
             self.fields.pop('note')
             self.fields.pop('payment_method')
             self.fields.pop('total_price')
+
+    def _get_next_valid_time(self, current_time):
+        """根據店家營業時間，回傳下個合法取餐時間"""
+        if not self.store:
+            return current_time  # 沒有 store 就不處理
+
+        opening_time = self.store.opening_time  # time object
+        closing_time = self.store.closing_time  # time object
+        current_store_time = current_time.time()
+
+        # 若 current_time 在營業時間區間內（含開，不含關） → 合法
+        if opening_time <= current_store_time < closing_time:
+            return current_time
+
+        # 早於開店 → 今日開店時間
+        if current_store_time < opening_time:
+            return datetime.combine(current_time.date(), opening_time)
+
+        # 晚於打烊 → 明日開店時間
+        next_day = current_time.date() + timedelta(days=1)
+        return datetime.combine(next_day, opening_time)
 
     # 在儲存訂單時，依訂單項目計算總金額
     def save(self, commit=True):

--- a/orders/signals.py
+++ b/orders/signals.py
@@ -36,7 +36,7 @@ def handle_order_status_change(sender, instance, **kwargs):
     # 處理超時未取餐
     if (
         instance.order_status == OrderStatus.READY
-        and instance.pickup_time < timezone.now()
+        and instance.pickup_time < timezone.now() - timezone.timedelta(hours=12)
     ):
         instance.order_status = OrderStatus.NO_SHOW
 

--- a/orders/views.py
+++ b/orders/views.py
@@ -24,7 +24,11 @@ def index(req):
             return redirect('carts:index')
 
         cart = get_object_or_404(Cart, id=cart_id)
-        form = OrderForm(req.POST, mode='create')
+        form = OrderForm(
+            req.POST,
+            store=cart.store,
+            mode='create',
+        )
         cart_items = cart.items.all()
 
         for cart_item in cart.items.all():
@@ -147,6 +151,7 @@ def new(req):
 
     form = OrderForm(
         mode='create',
+        store=cart.store,
         initial={
             'store': cart.store,
             'note': cart.note,

--- a/src/scripts/datePicker.js
+++ b/src/scripts/datePicker.js
@@ -2,7 +2,18 @@ import { initPickupTimePicker } from './flatpickr/main.js';
 
 export const DatePicker = () => ({
   init() {
-    initPickupTimePicker('#id_pickup_time', 'healthy_style');
+    const openingTime = this.$el.dataset.openingTime;
+    const closingTime = this.$el.dataset.closingTime;
+
+    initPickupTimePicker('#id_pickup_time', 'healthy_style', {
+      minTime: openingTime,
+      maxTime: closingTime,
+      enableTime: true,
+      dateFormat: 'Y-m-d\\TH:i',
+      minuteIncrement: 10,
+      altInput: true,
+      altFormat: 'Y年m月d日 H:i',
+    });
     initPickupTimePicker('#id_date_of_birth', 'healthy_style', {
       enableTime: false,
       dateFormat: 'Y-m-d',

--- a/templates/orders/components/ordering_step1.html
+++ b/templates/orders/components/ordering_step1.html
@@ -53,7 +53,7 @@
           <span class="text-lg font-medium text-gray-700">取貨方式：自取</span>
         </div>
 
-        <div class="flex flex-col gap-4">
+        <div class="flex flex-col">
           <div x-data="dataPicker" x-init="init" class="mb-4 flex items-center">
             <div class="mr-2 flex h-8 w-8 items-center justify-center rounded-full bg-[#5a855a] text-white">
               <i class="fa-regular fa-clock"></i>

--- a/templates/orders/components/ordering_step1.html
+++ b/templates/orders/components/ordering_step1.html
@@ -54,7 +54,7 @@
         </div>
 
         <div class="flex flex-col">
-          <div x-data="dataPicker" x-init="init" class="mb-4 flex items-center">
+          <div x-data="dataPicker" x-init="init" data-cart-id="{{ cart.id }}" data-opening-time="{{ cart.store.opening_time|date:'H:i' }}" data-closing-time="{{ cart.store.closing_time|date:'H:i' }}" class="mb-4 flex items-center">
             <div class="mr-2 flex h-8 w-8 items-center justify-center rounded-full bg-[#5a855a] text-white">
               <i class="fa-regular fa-clock"></i>
             </div>


### PR DESCRIPTION
close #280 

以 issue/274 (PR #275)為基底，為了方便 code review，PR 先暫時選擇 rebase 到 issue/274，
等確認沒問題、 issue/274 rebase 到 dev 後再改成 rebase 到 dev 

- 新增 _get_next_valid_time() 方法於訂單 forms 中，根據商家營業時間決定預設的取餐時間
- 表單初始化需從 view 傳入 store 實例
- 前端 flatpickr 加入時間選擇器限制以避免選取非營業時段
- no show 訂單狀態改成超過 pickup time 12 小時候才會成立