### PR TITLE
修正第三方登入錯誤

### DIFF
--- a/members/models.py
+++ b/members/models.py
@@ -69,7 +69,7 @@ class Member(models.Model):
         self.favorite_records.all().delete()
         self.collection_set.all().delete()
         self.save(using=using, update_fields=['deleted_at', 'deleted_email'])
-        self.user.delete(using=using, keep_parents=keep_parents)
+        self.user.delete()
 
 
 class Favorite(models.Model):

--- a/users/adapters.py
+++ b/users/adapters.py
@@ -1,8 +1,8 @@
 import logging
 
+from allauth.account.models import EmailAddress
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from django.contrib.auth import get_user_model
-from allauth.account.models import EmailAddress
 
 logger = logging.getLogger(__name__)
 User = get_user_model()
@@ -10,32 +10,35 @@ User = get_user_model()
 
 class MySocialAccountAdapter(DefaultSocialAccountAdapter):
     def pre_social_login(self, request, sociallogin):
+        """
+        若該 email 已存在於系統，則將這個 social account 綁定到該使用者。
+        不進行寫入 EmailAddress，避免 user 尚未儲存時寫入失敗。
+        """
         email = sociallogin.account.extra_data.get('email')
         if email:
             try:
                 user = User.objects.get(email=email)
-                sociallogin.connect(request, user)  # 將 LINE 登入綁定到此使用者
+                if not sociallogin.is_existing:
+                    sociallogin.connect(request, user)
             except User.DoesNotExist:
-                pass  # 如果不存在就照預設邏輯走
-            # 強制建立已驗證的 EmailAddress
-            EmailAddress.objects.update_or_create(
-                user=sociallogin.user,
-                email=email,
-                defaults={"verified": True, "primary": True},
-            )
+                pass
 
     def is_auto_signup_allowed(self, request, sociallogin):
         print('LINE 回傳資料：', sociallogin.account.extra_data)
-        return True  # 暫時允許 auto signup 觀察是否有 email
+        return True
 
     def is_open_for_signup(self, request, sociallogin):
-        # 允許自動註冊，跳過 signup 頁
         return True
 
     def save_user(self, request, sociallogin, form=None):
+        """
+        將社群登入的使用者資訊儲存至本地帳號，並確保有 email、username 等必要欄位。
+        此處也建立 EmailAddress 紀錄並設定角色。
+        """
         user = sociallogin.user
         extra_data = sociallogin.account.extra_data
 
+        # 設定帳號基本資訊
         if not user.username:
             user.username = (
                 extra_data.get('email') or user.email or sociallogin.account.uid
@@ -49,6 +52,19 @@ class MySocialAccountAdapter(DefaultSocialAccountAdapter):
                 'displayName', ''
             )
 
+        # 👉 自動加上 member 角色
+        if not user.role:
+            user.role = 'member'
+
         user.save()
         sociallogin.save(request)
+
+        # 設定已驗證 email
+        if user.email:
+            EmailAddress.objects.update_or_create(
+                user=user,
+                email=user.email,
+                defaults={'verified': True, 'primary': True},
+            )
+
         return user


### PR DESCRIPTION
close #292 

- 目前第三方登入後，如果刪除帳號再次登入，處理流程上會因為找不到user資訊產生伺服器錯誤
- 修改adapters.py流程，在user確定建立後再做第三方綁定 