### PR TITLE
修正手機網頁上無法新增商品（增加請求體大小限制）

### DIFF
--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -14,6 +14,11 @@ server {
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers on;
 
+    # 添加這行來增加請求體大小限制
+    # 這裡將限制設置為 5 兆字節 (5M)，您可以根據您的需求調整
+    # 如果您的圖片最大處理後是 0.59MB，設置 5M 或 10M 應該足夠了。
+    client_max_body_size 5M;
+
     location / {
         proxy_pass http://web:8000;
         proxy_set_header Host $host;


### PR DESCRIPTION
根據手機上 413 Request Entity Too Large 的錯誤訊息，問題出在請求體的大小超過了伺服器（Nginx 在這裡扮演代理伺服器的角色）的限制。